### PR TITLE
Using Service Objects to refactor RequestController

### DIFF
--- a/app/services/create_request_service.rb
+++ b/app/services/create_request_service.rb
@@ -1,0 +1,59 @@
+class CreateRequestService
+  attr_reader :user, :params, :selected_books, :errors, :request
+
+  def initialize user, params
+    @user = user
+    @params = params
+    @selected_books = params[:selected_books]&.map(&:to_i)
+    @errors = []
+  end
+
+  def call
+    return false if has_unreturned_books? || invalid_borrow_amount?
+
+    ActiveRecord::Base.transaction do
+      create_borrow_request!
+      delete_selected_books!
+    end
+    true
+  rescue ActiveRecord::RecordInvalid => e
+    @errors << e.record.errors.full_messages.join(", ")
+    false
+  end
+
+  private
+
+  def invalid_borrow_amount?
+    is_book_present = @selected_books.present?
+    is_over_size = @selected_books&.size.to_i > Settings.request.allow_amount
+    return false if is_book_present && !is_over_size
+
+    @errors << I18n.t("error.cant_borrow_more_than",
+                      allow_amount: Settings.request.allow_amount)
+    @errors = [I18n.t("error.less_than_a_book")] unless is_book_present
+    true
+  end
+
+  def has_unreturned_books?
+    return false if @user.borrow_requests.uncompleted.blank?
+
+    @errors = [I18n.t("error.has_unreturned_books")]
+    true
+  end
+
+  def create_borrow_request!
+    @request = @user.borrow_requests.create!(
+      start_date: params[:start_date],
+      end_date: params[:end_date]
+    )
+    @request.requested_books.create!(build_book_params)
+  end
+
+  def delete_selected_books!
+    @user.selected_books.by_book_ids(@selected_books).delete_all
+  end
+
+  def build_book_params
+    @selected_books&.map{|book_id| {book_id:}}
+  end
+end

--- a/app/services/handle_request_service.rb
+++ b/app/services/handle_request_service.rb
@@ -1,0 +1,85 @@
+class HandleRequestService
+  attr_reader :user, :request, :new_status, :note, :errors
+
+  def initialize user, request, new_status, note = nil
+    @user = user
+    @request = request
+    @new_status = new_status.to_sym
+    @note = note
+    @errors = []
+  end
+
+  def call
+    return false unless new_status_is_valid? && has_out_of_stock_book?
+
+    case @new_status
+    when :borrowing, :returned
+      process_accept_or_return_request
+    when :declined
+      return false unless process_decline_request?
+    when :overdue
+      change_status
+    end
+
+    send_mail and return true
+  rescue ActiveRecord::RecordInvalid => e
+    @errors << e.record.errors.full_messages.join(", ")
+    false
+  end
+
+  private
+
+  def new_status_is_valid?
+    if Request::ALLOWED_ACTIONS[@request.status].include? @new_status
+      true
+    else
+      @errors << I18n.t("error.validate_status_allowed",
+                        current_status: @request.status,
+                        new_status: @new_status)
+      false
+    end
+  end
+
+  def has_out_of_stock_book?
+    if @request.books.with_zero_in_stock.exists? || @new_status == :declined
+      true
+    else
+      @errors << I18n.t("error.contain_out_of_stock_books")
+      false
+    end
+  end
+
+  def change_status
+    @request.update! status: new_status, processor: user
+  end
+
+  def change_book_amount amount
+    @request.books.each do |book|
+      book.update!(in_stock: book.in_stock + amount)
+    end
+  end
+
+  def process_accept_or_return_request
+    ActiveRecord::Base.transaction do
+      change_status
+      amount = (@new_status == :borrowing ? -1 : 1)
+      change_book_amount(amount)
+    end
+  end
+
+  def process_decline_request?
+    if note.present?
+      @request.update! status: new_status, note:, processor: user
+      true
+    else
+      @errors << I18n.t("error.missing_reason")
+      false
+    end
+  end
+
+  def send_mail
+    return unless @request.borrower.email == Settings.demo_email
+
+    SendEmailJob.perform_later(@request.borrower.id, @new_status.to_s)
+  end
+end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,4 +1,4 @@
-:concurrency: <%= Settings.sidekiq_concurrency %>
+:concurrency: <%= ENV.fetch("SIDEKIQ_CONCURRENCY", 5) %>
 :queues:
   - default
   - mailers

--- a/spec/factories/requests.rb
+++ b/spec/factories/requests.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
 
     trait :with_books do
       after(:create) do |request|
-        book = create(:book, author: create(:author), publisher: create(:publisher), genre: create(:genre))
+        book = create(:book, author: create(:author), publisher: create(:publisher), genre: create(:genre), in_stock: 3)
         create(:requested_book, request: request, book: book)
       end
     end


### PR DESCRIPTION
## Related Tickets
- [#TicketID](https://edu-redmine.sun-asterisk.vn/issues/???)

## WHAT (optional)
- Refactor RequestController sử dụng Service Object

## HOW
- Tách logic tạo request và xử lý request, các điều kiện vào 2 service object riêng
- Ở controller chỉ cần tạo Service Object và gọi method call

## WHY (optional)
- Because in previous version - number just depends on `normal` items. But in new version, we have `state` and `confirm_state` depends on both `normal` + `not_normal` items.

## Evidence (Screenshot or Video)
Rubocop:
![image](https://github.com/user-attachments/assets/947ad200-3e13-4ae9-8e6d-ac7c540f3bd6)
